### PR TITLE
fix: properly access platform name

### DIFF
--- a/src/rez_nushell/rezplugins/shell/nu.py
+++ b/src/rez_nushell/rezplugins/shell/nu.py
@@ -13,7 +13,6 @@ from rez.shells import Shell
 from rez.config import config
 from rez.rex import RexExecutor, EscapedString
 from rez.utils.execution import Popen
-from rez.utils.platform_ import platform_
 from rez.util import shlex_join
 from rez.system import system
 from rezplugins.shell._utils.windows import to_windows_path, get_syspaths_from_registry
@@ -76,7 +75,7 @@ class Nushell(Shell):
             cls.syspaths = config.standard_system_paths
             return cls.syspaths
 
-        if platform_.startswith('win'):
+        if system.platform.startswith('win'):
             paths = get_syspaths_from_registry()
         else:
             paths = os.environ['PATH'].split(os.pathsep)
@@ -196,7 +195,7 @@ class Nushell(Shell):
         return f'"{result}"'
 
     def normalize_path(self, path):
-        if platform_.name == "windows":
+        if system.platform == "windows":
             return to_windows_path(path)
         else:
             return path

--- a/tests/test_nu.py
+++ b/tests/test_nu.py
@@ -41,14 +41,12 @@ def test_expand_vars(monkeypatch):
     assert lines[-1] == "}"
 
 def test_normalize_path_windows(monkeypatch):
-    class MockPlatform:
-        name = "windows"
-    monkeypatch.setattr("rez_nushell.rezplugins.shell.nu.platform_", MockPlatform)
+    monkeypatch.setattr("rez.system.system.platform", "windows")
     shell = Nushell()
     assert shell.normalize_path("C:/foo/bar") == "C:\\foo\\bar"
 
 def test_normalize_path_linux(monkeypatch):
-    monkeypatch.setattr("rez.utils.platform_.platform_.name", "linux")
+    monkeypatch.setattr("rez.system.system.platform", "linux")
     shell = Nushell()
     assert shell.normalize_path("/foo/bar") == "/foo/bar"
 


### PR DESCRIPTION
### **User description**
This commit updates the plugin to use `system.platform` string instead of the `platform_` object.

This fixes an issue when detecting the platform, where `platform_` would improperly be accessed as a string (with `str.startswith`).


___

### **Auto-created Ticket**

[#11](https://github.com/doubleailes/rez_nushell_plugin/issues/11)

### **PR Type**
Bug fix


___

### **Description**
- Replace incorrect `platform_` object with `system.platform` string

- Fix platform detection using proper string comparison method

- Remove unused import from `rez.utils.platform_` module


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["platform_ object<br/>incorrect usage"] -->|"replaced with"| B["system.platform<br/>string value"]
  B -->|"enables proper"| C["str.startswith()<br/>comparison"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>nu.py</strong><dd><code>Replace platform_ object with system.platform string</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/rez_nushell/rezplugins/shell/nu.py

<ul><li>Removed import of <code>platform_</code> from <code>rez.utils.platform_</code><br> <li> Updated <code>get_syspaths()</code> method to use <code>system.platform.startswith('win')</code> <br>instead of <code>platform_.startswith('win')</code><br> <li> Updated <code>normalize_path()</code> method to compare <code>system.platform == </code><br><code>"windows"</code> instead of <code>platform_.name == "windows"</code><br> <li> Fixed platform detection logic to use correct string attribute</ul>


</details>


  </td>
  <td><a href="https://github.com/doubleailes/rez_nushell_plugin/pull/10/files#diff-5453f72a59f1f2948d288cb793b12aeccc7e95d98d260216715195a4a03791b9">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

